### PR TITLE
Prefer dirty data over original data

### DIFF
--- a/lib/netbox_client_ruby/entity.rb
+++ b/lib/netbox_client_ruby/entity.rb
@@ -197,9 +197,8 @@ module NetboxClientRuby
         end
       end
 
-      return objectify(name, object_fields[name]) if object_fields.keys.include? name
-
       return dirty_data[name] if dirty_data.keys.include? name
+      return objectify(data[name], object_fields[name]) if object_fields.keys.include? name
       return data[name] if data.is_a?(Hash) && data.keys.include?(name)
 
       super
@@ -211,9 +210,8 @@ module NetboxClientRuby
       return false if name.end_with?('=') && readonly_fields.include?(name[0..-2])
       return false if name.end_with?('=') && instance_variables.include?(name[0..-2])
 
-      return true if object_fields.keys.include? name
-
       return true if dirty_data.keys.include? name
+      return true if object_fields.keys.include? name
       return true if data.is_a?(Hash) && data.keys.include?(name)
 
       super
@@ -294,14 +292,12 @@ module NetboxClientRuby
       end
     end
 
-    def objectify(name, klass_or_proc = nil)
-      raw_data = data[name]
-
+    def objectify(raw_data, klass_or_proc = nil)
       return nil if raw_data.nil?
 
       return data_to_obj(raw_data, klass_or_proc) unless raw_data.is_a? Array
 
-      data[name].map do |raw_data_entry|
+      raw_data.map do |raw_data_entry|
         data_to_obj(raw_data_entry, klass_or_proc)
       end
     end

--- a/spec/netbox_client_ruby/entity_spec.rb
+++ b/spec/netbox_client_ruby/entity_spec.rb
@@ -184,8 +184,9 @@ describe NetboxClientRuby::Entity, faraday_stub: true do
 
       context 'save with more data' do
         let(:hash) { { 'one' => 1, 'two' => 2 } }
+        let(:array) { [1, 2, 3] }
         let(:number) { 3 }
-        let(:request_params) { { 'name' => name, 'number' => number, 'hash' => hash } }
+        let(:request_params) { { 'name' => name, 'number' => number, 'hash' => hash, 'array' => array } }
 
         it 'sends all the data' do
           expect(faraday).to receive(:post).and_call_original
@@ -193,8 +194,30 @@ describe NetboxClientRuby::Entity, faraday_stub: true do
           subject[:name] = name
           subject.number = number
           subject.hash = hash
+          subject.array = array
 
           subject.save
+        end
+      end
+
+      context 'setting an object field' do
+        let(:test_object) { Object.new }
+        let(:request_params) { { 'an_object' => test_object } }
+
+        it 'does not call the remote yet' do
+          expect(faraday).to_not receive(:post)
+
+          subject.an_object = test_object
+
+          expect(subject.an_object).to be(test_object)
+        end
+
+        it 'sends the object to faraday for serialization' do
+          expect(faraday).to receive(:post).and_call_original
+
+          subject.an_object = test_object
+
+          expect(subject.save).to be(subject)
         end
       end
 


### PR DESCRIPTION
Previously, when data was set on an object-field of an entity, but the
entity in questions was not yet fetched from the server, it would be
fetched due to too high prioritisation of the objectify fields.