### PR TITLE
Wraps prefixes in an IPAddress object as well

### DIFF
--- a/lib/netbox_client_ruby/api/ipam/prefix.rb
+++ b/lib/netbox_client_ruby/api/ipam/prefix.rb
@@ -5,6 +5,7 @@ require 'netbox_client_ruby/api/ipam/vrf'
 require 'netbox_client_ruby/api/ipam/vlan'
 require 'netbox_client_ruby/api/ipam/vlan_group'
 require 'netbox_client_ruby/api/tenancy/tenant'
+require 'ipaddress'
 
 module NetboxClientRuby
   class Prefix
@@ -20,7 +21,8 @@ module NetboxClientRuby
       tenant: proc { |raw_data| NetboxClientRuby::Tenant.new raw_data['id'] },
       vlan: proc { |raw_data| NetboxClientRuby::Vlan.new raw_data['id'] },
       status: proc { |raw_data| NetboxClientRuby::PrefixStatus.new raw_data['value'] },
-      role: proc { |raw_data| NetboxClientRuby::Role.new raw_data['id'] }
+      role: proc { |raw_data| NetboxClientRuby::Role.new raw_data['id'] },
+      prefix: proc { |raw_data| IPAddress.parse raw_data }
     )
     readonly_fields :display_name
   end

--- a/spec/netbox_client_ruby/api/ipam/prefix_spec.rb
+++ b/spec/netbox_client_ruby/api/ipam/prefix_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
+require 'ipaddress'
 
 describe NetboxClientRuby::Prefix, faraday_stub: true do
   let(:class_under_test) { NetboxClientRuby::Prefix }
   let(:base_url) { '/api/ipam/prefixes/' }
   let(:response) { File.read("spec/fixtures/ipam/prefix_#{entity_id}.json") }
 
-  let(:expected_prefix) { '10.2.0.0/16' }
+  let(:expected_prefix) { IPAddress.parse '10.2.0.0/16' }
   let(:entity_id) { 3 }
   let(:request_url) { "#{base_url}#{entity_id}.json" }
 
@@ -35,7 +36,8 @@ describe NetboxClientRuby::Prefix, faraday_stub: true do
     tenant: NetboxClientRuby::Tenant,
     vlan: NetboxClientRuby::Vlan,
     status: NetboxClientRuby::PrefixStatus,
-    role: NetboxClientRuby::Role
+    role: NetboxClientRuby::Role,
+    prefix: IPAddress
   }.each_pair do |method_name, expected_type|
     context 'entity with references' do
       describe ".#{method_name}" do
@@ -84,7 +86,7 @@ describe NetboxClientRuby::Prefix, faraday_stub: true do
   end
 
   describe '.update' do
-    let(:prefix) { '192.168.0.0/16' }
+    let(:prefix) { IPAddress.parse '192.168.0.0/16' }
     let(:request_method) { :patch }
     let(:request_params) { { 'prefix' => prefix } }
 


### PR DESCRIPTION
So that it works similar to the ip-addresses entity.