### PR TITLE
Don't require pry inside the client code

### DIFF
--- a/lib/netbox_client_ruby/entities.rb
+++ b/lib/netbox_client_ruby/entities.rb
@@ -1,6 +1,5 @@
 require 'netbox_client_ruby/entity'
 require 'netbox_client_ruby/error/local_error'
-require 'pry'
 
 module NetboxClientRuby
   module Entities


### PR DESCRIPTION
Since this is a development dependency it does not get installed by
bundler and on hosts where pry is not installed system-wide
netbox-client fails to load with ``require': cannot load such file --
pry (LoadError)`