### PR TITLE
Linux fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 
 quickstart.rb
 *.gz
+
+/vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: ruby
 before_install: gem install bundler
+rvm:
+  - 2.3
+  - 2.4
 notifications:
   email:
     on_success: never

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM ruby:2.3.4-alpine
-MAINTAINER development@nine.ch
 
 RUN apk add --no-cache git
 
@@ -7,6 +6,6 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY . ./
-RUN bundle install --jobs 4 --quiet
+RUN bundle install --jobs 4 --quiet --deployment
 
 CMD docker/start.sh

--- a/docker/start.test.sh
+++ b/docker/start.test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec bundle exec rspec
+exec bundle exec rake

--- a/lib/netbox_client_ruby/api/dcim/device.rb
+++ b/lib/netbox_client_ruby/api/dcim/device.rb
@@ -1,7 +1,7 @@
 require 'netbox_client_ruby/entity'
 require 'netbox_client_ruby/api/dcim/device_type'
 require 'netbox_client_ruby/api/dcim/device_role'
-require 'netbox_client_ruby/api/tenancy/Tenant'
+require 'netbox_client_ruby/api/tenancy/tenant'
 require 'netbox_client_ruby/api/dcim/platform'
 require 'netbox_client_ruby/api/dcim/site'
 require 'netbox_client_ruby/api/dcim/rack'


### PR DESCRIPTION
Branch & PR named like this, because macOS & windows aren't so (case) sensitive (by default).

But to be fair, I was just not careful enough while "find & replace" 'ing things and a Linux-based system was pointing this out.