### PR TITLE
Improved process for creating new entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,32 @@ puts "The first site is called #{first_site.name}."
 devices_of_site = NetboxClientRuby.dcim.devices.filter(site: first_site.slug)
 puts "#{devices_of_site.total} devices belong to the site. #{devices_of_site}.length devices have been fetched."
 
+# get a site by id
+s = NetboxClientRuby.dcim.site(1)
+
+# update a site
+s.update(name: 'Zurich', slug: 'zrh')
+
+# update a site (alternative)
+s.name = 'Amsterdam'
+s.slug = 'ams'
+s.save
+
+# create a site
+new_s = NetboxClientRuby::DCIM::Site.new
+new_s.name = 'Berlin'
+new_s.slug = 'ber'
+new_s.save
+
+# create a site (alternative)
+new_s = NetboxClientRuby::DCIM::Site
+          .new(name: 'Berlin', slug: 'ber')
+          .save
+
+# delete a site
+s = NetboxClientRuby.dcim.site(1)
+s.delete
+
 # working with secrets
 secrets = NetboxClientRuby.secrets.secrets
 puts "#{secrets.total} secrets are in your Netbox."

--- a/spec/netbox_client_ruby/entity_spec.rb
+++ b/spec/netbox_client_ruby/entity_spec.rb
@@ -23,6 +23,7 @@ describe NetboxClientRuby::Entity, faraday_stub: true do
 
     id test_id: 'id'
     readonly_fields :counter
+    creation_path 'tests/'
     # not deletable
 
     path 'tests/42'
@@ -182,6 +183,17 @@ describe NetboxClientRuby::Entity, faraday_stub: true do
         subject.save
       end
 
+      it 'parses the response' do
+        expect(faraday).to_not receive(:get)
+
+        subject[:name] = name
+
+        subject.save
+
+        expect(subject.test_id).to be(43)
+        expect(subject.boolean).to be(true)
+      end
+
       context 'save with more data' do
         let(:hash) { { 'one' => 1, 'two' => 2 } }
         let(:array) { [1, 2, 3] }
@@ -221,15 +233,14 @@ describe NetboxClientRuby::Entity, faraday_stub: true do
         end
       end
 
-      it 'parses the response' do
-        expect(faraday).to_not receive(:get)
+      context 'by supplying values through the constructor' do
+        let(:subject) { TestEntity2.new name: name }
 
-        subject[:name] = name
+        it 'does a proper POST upon save' do
+          expect(faraday).to receive(:post).and_call_original
 
-        subject.save
-
-        expect(subject.test_id).to be(43)
-        expect(subject.boolean).to be(true)
+          subject.save
+        end
       end
     end
   end


### PR DESCRIPTION
The constructor can now be used to pass initial 'dirty' values:

    s=NetboxClientRuby::DCIM::Site.new(name: 'Zurich', slug: 'zrh')
    s.save

So, theoretically, this can be used to fetch and update a site in one operation:

    s=NetboxClientRuby::DCIM::Site.new(id: 1, name: 'Zurich', slug: 'zrh')
    s.save

This would update the name and slug for the site with the id 1. But the ordinal way should be preferred, because it is more explicit:

    NetboxClientRuby.dcim.site(1).update(name: 'Zurich', slug: 'zrh')