### PR TITLE
🐞 Detects virtual machine interfaces

### DIFF
--- a/lib/netbox_client_ruby/api/ipam/ip_address.rb
+++ b/lib/netbox_client_ruby/api/ipam/ip_address.rb
@@ -1,4 +1,5 @@
 require 'netbox_client_ruby/entity'
+require 'netbox_client_ruby/error/local_error'
 require 'netbox_client_ruby/api/dcim/interface'
 require 'netbox_client_ruby/api/ipam/vrf'
 require 'netbox_client_ruby/api/tenancy/tenant'
@@ -24,7 +25,6 @@ module NetboxClientRuby
         vrf: proc { |raw_data| Vrf.new raw_data['id'] },
         tenant: proc { |raw_data| Tenancy::Tenant.new raw_data['id'] },
         status: proc { |raw_data| STATUS_VALUES.key(raw_data['value']) || raw_data['value'] },
-        interface: proc { |raw_data| DCIM::Interface.new raw_data['id'] },
         address: proc { |raw_ip| IPAddress.parse(raw_ip) }
       )
       readonly_fields :display_name
@@ -32,6 +32,18 @@ module NetboxClientRuby
       def status=(value)
         status_code_lookup = STATUS_VALUES.fetch(value, value)
         method_missing(:status=, status_code_lookup)
+      end
+
+      def interface
+        interface_data = data['interface']
+
+        return nil unless interface_data
+
+        if interface_data.key? ('virtual_machine')
+          Virtualization::Interface.new interface_data['id']
+        else interface_data.key? ('device')
+          DCIM::Interface.new interface_data['id']
+        end
       end
     end
   end

--- a/spec/fixtures/ipam/ip-address_2.json
+++ b/spec/fixtures/ipam/ip-address_2.json
@@ -1,0 +1,29 @@
+{
+  "id": 2,
+  "family": 4,
+  "address": "10.20.30.40/24",
+  "vrf": null,
+  "tenant": null,
+  "status": {
+    "value": 1,
+    "label": "Active"
+  },
+  "role": null,
+  "interface": {
+    "id": 1,
+    "url": "http://netboxclientruby.docker/api/virtualization/interfaces/1/",
+    "device": null,
+    "virtual_machine": {
+      "id": 1,
+      "url": "http://netboxclientruby.docker/api/virtualization/virtual-machines/1/",
+      "name": "VirtualMachine1"
+    },
+    "name": "VirtualMachineInterface1"
+  },
+  "description": "",
+  "nat_inside": null,
+  "nat_outside": null,
+  "custom_fields": {},
+  "created": "2018-04-10",
+  "last_updated": "2018-04-10T12:05:08.263361Z"
+}

--- a/spec/fixtures/ipam/ip-address_3.json
+++ b/spec/fixtures/ipam/ip-address_3.json
@@ -1,0 +1,19 @@
+{
+  "id": 3,
+  "family": 4,
+  "address": "20.30.40.50/24",
+  "vrf": null,
+  "tenant": null,
+  "status": {
+    "value": 1,
+    "label": "Active"
+  },
+  "role": null,
+  "interface": null,
+  "description": "",
+  "nat_inside": null,
+  "nat_outside": null,
+  "custom_fields": {},
+  "created": "2018-04-10",
+  "last_updated": "2018-04-10T13:17:52.286492Z"
+}

--- a/spec/netbox_client_ruby/api/dcim/interface_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/interface_spec.rb
@@ -29,6 +29,22 @@ describe NetboxClientRuby::DCIM::Interface, faraday_stub: true do
     end
   end
 
+  describe '#device' do
+    it 'should fetch data' do
+      expect(faraday).to receive(:get).and_call_original
+
+      expect(subject.device).to_not be_nil
+    end
+
+    it 'shall be a device instance' do
+      expect(subject.device).to be_a(NetboxClientRuby::DCIM::Device)
+    end
+
+    it 'shall be the expected device' do
+      expect(subject.device.id).to eq(1)
+    end
+  end
+
   describe '.delete' do
     let(:request_method) { :delete }
     let(:response_status) { 204 }

--- a/spec/netbox_client_ruby/api/ipam/ip_address_spec.rb
+++ b/spec/netbox_client_ruby/api/ipam/ip_address_spec.rb
@@ -30,10 +30,55 @@ describe NetboxClientRuby::IPAM::IpAddress, faraday_stub: true do
     end
   end
 
+  describe '#interface' do
+    context 'no interface' do
+      let(:entity_id) { 3 }
+
+      it 'shall fetch the data' do
+        expect(faraday).to receive(:get).and_call_original
+
+        subject.interface
+      end
+
+      it 'shall return nil' do
+        expect(subject.interface).to be_nil
+      end
+    end
+
+    context 'virtual interface' do
+      let(:entity_id) { 2 }
+
+      it 'shall fetch the data' do
+        expect(faraday).to receive(:get).and_call_original
+
+        subject.interface
+      end
+
+      it 'shall return a virtual interface' do
+        expect(subject.interface).to be_a(NetboxClientRuby::Virtualization::Interface)
+        expect(subject.interface.id).to eq(1)
+      end
+    end
+
+    context 'physical device interface' do
+      let(:entity_id) { 1 }
+
+      it 'shall fetch the data' do
+        expect(faraday).to receive(:get).and_call_original
+
+        subject.interface
+      end
+
+      it 'shall return a virtual interface' do
+        expect(subject.interface).to be_a(NetboxClientRuby::DCIM::Interface)
+        expect(subject.interface.id).to eq(3)
+      end
+    end
+  end
+
   {
     vrf: NetboxClientRuby::IPAM::Vrf,
     tenant: NetboxClientRuby::Tenancy::Tenant,
-    interface: NetboxClientRuby::DCIM::Interface,
     status: Symbol
   }.each_pair do |method_name, expected_type|
     describe ".#{method_name}" do


### PR DESCRIPTION
Previously, when hoping from the IP address to the interface associated
with that IP, NetboxClientRuby would always return a `DCIM::Interface`
instance.

```ruby
# would always return a DCIM::Interface
NetboxClientRuby.ip_addresses.first.interface
```

This is wrong, because if the IP address is assigned to a virtual
machine, then we would expected to receive a
`Virtualization::Interface` instead.

This commit fixes #24.