### PR TITLE
fix cluster -> site link

### DIFF
--- a/lib/netbox_client_ruby/api/virtualization/cluster.rb
+++ b/lib/netbox_client_ruby/api/virtualization/cluster.rb
@@ -14,7 +14,7 @@ module NetboxClientRuby
       creation_path 'virtualization/clusters/'
       object_fields(
         group: proc { |raw_data| ClusterGroup.new raw_data['id'] },
-        site: proc { |raw_data| Site.new raw_data['id'] },
+        site: proc { |raw_data| DCIM::Site.new raw_data['id'] },
         type: proc { |raw_data| ClusterType.new raw_data['id'] },
       )
     end

--- a/spec/netbox_client_ruby/api/virtualization/cluster_spec.rb
+++ b/spec/netbox_client_ruby/api/virtualization/cluster_spec.rb
@@ -28,6 +28,22 @@ describe NetboxClientRuby::Virtualization::Cluster, faraday_stub: true do
     end
   end
 
+  describe '#site' do
+    it 'should fetch the data' do
+      expect(faraday).to receive(:get).and_call_original
+
+      expect(subject.name).to_not be_nil
+    end
+
+    it 'shall be a site instance' do
+      expect(subject.site).to be_a(NetboxClientRuby::DCIM::Site)
+    end
+
+    it 'shall be the expected site' do
+      expect(subject.site.id).to eq(1)
+    end
+  end
+
   describe '.delete' do
     let(:request_method) { :delete }
     let(:response_status) { 204 }


### PR DESCRIPTION
Currently you can't get a cluster's site because it's looking up the wrong constant. This just qualifies the constant so that it looks in `DCIM` instead of `Virtualization` and adds a spec for regressions.