### PR TITLE
Add url method for entities

### DIFF
--- a/lib/netbox_client_ruby/entity.rb
+++ b/lib/netbox_client_ruby/entity.rb
@@ -173,6 +173,10 @@ module NetboxClientRuby
       patch
     end
 
+    def url
+      "#{connection.url_prefix}#{path}"
+    end
+
     def raw_data!
       data
     end

--- a/spec/netbox_client_ruby/entity_spec.rb
+++ b/spec/netbox_client_ruby/entity_spec.rb
@@ -114,6 +114,12 @@ describe NetboxClientRuby::Entity, faraday_stub: true do
     it 'returns the raw data' do
       expect(subject.raw_data!).to eq raw_data
     end
+
+    describe '#url' do
+      it 'returns the url of the resource' do
+        expect(subject.url).to eq 'http://netbox.test/api/tests/42'
+      end
+    end
   end
 
   describe 'send values' do


### PR DESCRIPTION
## Goal

Sometimes, we fetch a resource, and we would like to know the full uri of that resource.

This method is here to provide a link to that resource.