### PR TITLE
Loosen dependency constraint on faraday_middleware

### DIFF
--- a/netbox-client-ruby.gemspec
+++ b/netbox-client-ruby.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'ipaddress', '~> 0.8', '>= 0.8.3'
   spec.add_runtime_dependency 'openssl', '~> 2.0', '>= 2.0.5'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.5'

--- a/netbox-client-ruby.gemspec
+++ b/netbox-client-ruby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-configurable', '~> 0.1'
   spec.add_runtime_dependency 'faraday', '~> 0.11', '>= 0.11.0'
   spec.add_runtime_dependency 'faraday-detailed_logger', '~> 2.1'
-  spec.add_runtime_dependency 'faraday_middleware', '~> 0.11.0'
+  spec.add_runtime_dependency 'faraday_middleware', '~> 0.11'
   spec.add_runtime_dependency 'ipaddress', '~> 0.8', '>= 0.8.3'
   spec.add_runtime_dependency 'openssl', '~> 2.0', '>= 2.0.5'
 


### PR DESCRIPTION
The constraint on faraday was already loosened to `>~ 0.11`, but
`faraday_middleware` was still limited to `0.11.*`.