### PR TITLE
fix: ipam interface should check on virtualmachine nil state

### DIFF
--- a/lib/netbox_client_ruby/api/ipam/ip_address.rb
+++ b/lib/netbox_client_ruby/api/ipam/ip_address.rb
@@ -33,12 +33,8 @@ module NetboxClientRuby
         interface_data = data['interface']
 
         return nil unless interface_data
-
-        if interface_data.key?('virtual_machine')
-          Virtualization::Interface.new interface_data['id']
-        else
-          DCIM::Interface.new interface_data['id']
-        end
+        return Virtualization::Interface.new interface_data['id'] unless interface_data.dig('virtual_machine').nil?
+        return DCIM::Interface.new interface_data['id']
       end
     end
   end


### PR DESCRIPTION
Class IpAddress has a function called 'interface' returning a Virtualization or DCIM interface based on the existance of the 'virtual_machine' property. But in case of a DCIM interface this property exists as well, only set to nil. So this nil check has to be added to return the right interface.