### PR TITLE
Fix classname references in circuits

### DIFF
--- a/lib/netbox_client_ruby/api/circuits/circuit.rb
+++ b/lib/netbox_client_ruby/api/circuits/circuit.rb
@@ -24,12 +24,12 @@ module NetboxClientRuby
 
       object_fields(
         provider: proc do |raw_data|
-          Circuit::CircuitProvider.new raw_data['id']
+          Provider.new raw_data['id']
         end,
         status: proc do |raw_status|
           STATUS_VALUES.key(raw_status['value']) || raw_status['value']
         end,
-        type: proc { |raw_data| Circuit::CircuitType.new raw_data['id'] },
+        type: proc { |raw_data| CircuitType.new raw_data['id'] },
         tenant: proc { |raw_data| Tenancy::Tenant.new raw_data['id'] }
       )
     end

--- a/spec/netbox_client_ruby/api/circuits/circuit_spec.rb
+++ b/spec/netbox_client_ruby/api/circuits/circuit_spec.rb
@@ -36,6 +36,22 @@ module NetboxClientRuby
         end
       end
 
+      describe '.provider' do
+        it 'should be a Provider object' do
+          provider = subject.provider
+          expect(provider).to be_a Provider
+          expect(provider.id).to eq(1)
+        end
+      end
+
+      describe '.type' do
+        it 'should be a Type object' do
+          provider = subject.type
+          expect(provider).to be_a CircuitType
+          expect(provider.id).to eq(1)
+        end
+      end
+
       describe '.delete' do
         let(:request_method) { :delete }
         let(:response_status) { 204 }


### PR DESCRIPTION
`CircuitProvider` is just called `Provider` and lives in the same
namespace as the class it's being referred to.

The same counts for `CircuitType`, which lives in the same namespace as
well.

This fixes errors like

```
uninitialized constant NetboxClientRuby::Circuits::Circuit::CircuitProvider
```

When referencing `circuit.provider`.