### PR TITLE
calling a random method no longer tries to load the data when the :id has not been set

### DIFF
--- a/lib/netbox_client_ruby/entity.rb
+++ b/lib/netbox_client_ruby/entity.rb
@@ -130,6 +130,8 @@ module NetboxClientRuby
     end
 
     def reload
+      raise LocalError, "Can't 'reload', this object has never been saved" unless ids_set?
+
       @data = get
       revert
       self
@@ -259,7 +261,7 @@ module NetboxClientRuby
     end
 
     def get
-      response connection.get path unless @deleted
+      response connection.get path unless @deleted or !ids_set?
     end
 
     def readonly_fields

--- a/spec/netbox_client_ruby/entity_spec.rb
+++ b/spec/netbox_client_ruby/entity_spec.rb
@@ -395,4 +395,12 @@ describe NetboxClientRuby::Entity, faraday_stub: true do
       expect(b).to_not be a
     end
   end
+
+  describe 'calling an attribute' do
+    describe 'for an unsaved entity' do
+      it 'should raise a NoMethodError' do
+        expect { subject.unknown_attribute }.to raise_error NoMethodError
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi, this fixes issue #39 .

The problem seemed to be that calling a random method (like :flatten), would cause the entity to be retrieved from netbox whether the entity had an :id or not. In my case, the newly initialized entities weren't saved yet causing a LocalError to be raised.

I had to change the functionality. When !ids_set?, the instance won't be loaded from netbox but will raise NoMethodError instead of LocalError. It seems more accurate imho.

This fixes [Entity.new].flatten, because NoMethodError will now be raised.

I'm curious as to what you think of this change. Please keep in mind I have little experience with TDD.

Kind regards,
tvl2386

