### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7, 3.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/lib/netbox_client_ruby/connection.rb
+++ b/lib/netbox_client_ruby/connection.rb
@@ -10,7 +10,7 @@ module NetboxClientRuby
     }.freeze
 
     def self.new(options = {})
-      build_faraday(DEFAULT_OPTIONS.merge(options))
+      build_faraday(**DEFAULT_OPTIONS.merge(options))
     end
 
     def self.headers


### PR DESCRIPTION
It works on my Linux box with Ruby 3.0.1 by adding only one `**` keyword splat operator.