### PR TITLE
Add Journal Entries

### DIFF
--- a/lib/netbox_client_ruby/api/extras.rb
+++ b/lib/netbox_client_ruby/api/extras.rb
@@ -1,9 +1,12 @@
+require 'netbox_client_ruby/api/extras/journal_entry'
+require 'netbox_client_ruby/api/extras/journal_entries'
 require 'netbox_client_ruby/api/extras/tag'
 require 'netbox_client_ruby/api/extras/tags'
 
 module NetboxClientRuby
   module Extras
     {
+      journal_entries: JournalEntries,
       tags: Tags
     }.each_pair do |method_name, class_name|
       define_method(method_name) { class_name.new }
@@ -11,6 +14,7 @@ module NetboxClientRuby
     end
 
     {
+      journal_entry: JournalEntry,
       tag: Tag
     }.each_pair do |method_name, class_name|
       define_method(method_name) { |id| class_name.new id }

--- a/lib/netbox_client_ruby/api/extras/journal_entries.rb
+++ b/lib/netbox_client_ruby/api/extras/journal_entries.rb
@@ -1,0 +1,21 @@
+require 'netbox_client_ruby/entities'
+require 'netbox_client_ruby/api/extras/journal_entry'
+
+module NetboxClientRuby
+  module Extras
+    class JournalEntries
+      include Entities
+
+      path 'extras/journal-entries.json'
+      data_key 'results'
+      count_key 'count'
+      entity_creator :entity_creator
+
+      private
+
+      def entity_creator(raw_entity)
+        JournalEntry.new raw_entity['id']
+      end
+    end
+  end
+end

--- a/lib/netbox_client_ruby/api/extras/journal_entry.rb
+++ b/lib/netbox_client_ruby/api/extras/journal_entry.rb
@@ -1,0 +1,14 @@
+require 'netbox_client_ruby/entity'
+
+module NetboxClientRuby
+  module Extras
+    class JournalEntry
+      include Entity
+
+      id id: :id
+      deletable true
+      path 'extras/journal-entries/:id.json'
+      creation_path 'extras/journal-entries/'
+    end
+  end
+end

--- a/spec/fixtures/extras/journal_entries.json
+++ b/spec/fixtures/extras/journal_entries.json
@@ -1,0 +1,28 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "url": "http://netbox/api/extras/journal-entries/1/",
+      "display": "May 27, 2021 - 10:44 a.m. (Info)",
+      "assigned_object_type": "dcim.device",
+      "assigned_object_id": 1,
+      "assigned_object": {
+        "id": 1,
+        "url": "http://netbox/api/dcim/devices/1/",
+        "display": "New Device",
+        "name": "New Device",
+        "display_name": "New Device"
+      },
+      "created": "2021-05-27T10:44:54.686142Z",
+      "created_by": 1,
+      "kind": {
+        "value": "info",
+        "label": "Info"
+      },
+      "comments": "Hello"
+    }    
+  ]
+}

--- a/spec/fixtures/extras/journal_entry_1.json
+++ b/spec/fixtures/extras/journal_entry_1.json
@@ -1,0 +1,21 @@
+{
+  "id": 1,
+  "url": "http://netbox/api/extras/journal-entries/1/",
+  "display": "May 27, 2021 - 10:44 a.m. (Info)",
+  "assigned_object_type": "dcim.device",
+  "assigned_object_id": 1,
+  "assigned_object": {
+    "id": 1,
+    "url": "http://netbox/api/dcim/devices/1/",
+    "display": "New Device",
+    "name": "New Device",
+    "display_name": "New Device"
+  },
+  "created": "2021-05-27T10:44:54.686142Z",
+  "created_by": 1,
+  "kind": {
+    "value": "info",
+    "label": "Info"
+  },
+  "comments": "Hello"
+}

--- a/spec/netbox_client_ruby/api/extras/journal_entries_spec.rb
+++ b/spec/netbox_client_ruby/api/extras/journal_entries_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+module NetboxClientRuby
+  module Extras
+    describe JournalEntries, faraday_stub: true do
+      let(:expected_number_of_items) { 1 }
+      let(:expected_singular_type) { JournalEntry }
+
+      let(:response) { File.read('spec/fixtures/extras/journal_entries.json') }
+      let(:request_url) { '/api/extras/journal-entries.json' }
+      let(:request_url_params) do
+        { limit: NetboxClientRuby.config.netbox.pagination.default_limit }
+      end
+
+      context 'unpaged fetch' do
+        describe '#length' do
+          it 'shall be the expected length' do
+            expect(subject.length).to be expected_number_of_items
+          end
+        end
+
+        describe '#total' do
+          it 'shall be the expected total' do
+            expect(subject.total).to be expected_number_of_items
+          end
+        end
+      end
+
+      describe '#reload' do
+        it 'fetches the correct data' do
+          expect(faraday).to receive(:get).and_call_original
+          subject.reload
+        end
+
+        it 'caches the data' do
+          expect(faraday).to receive(:get).and_call_original
+          subject.total
+          subject.total
+        end
+
+        it 'reloads the data' do
+          expect(faraday).to receive(:get).twice.and_call_original
+          subject.reload
+          subject.reload
+        end
+      end
+
+      describe '#as_array' do
+        it 'return the correct amount' do
+          expect(subject.to_a.length).to be expected_number_of_items
+        end
+
+        it 'returns single instances' do
+          subject.to_a.each do |element|
+            expect(element).to be_a expected_singular_type
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/netbox_client_ruby/api/extras/journal_entry_spec.rb
+++ b/spec/netbox_client_ruby/api/extras/journal_entry_spec.rb
@@ -1,0 +1,150 @@
+require 'spec_helper'
+
+module NetboxClientRuby
+  module Extras
+    describe JournalEntry, faraday_stub: true do
+      let(:entity_id) { 1 }
+      let(:base_url) { '/api/extras/journal-entries/' }
+      let(:request_url) { "#{base_url}#{entity_id}.json" }
+      let(:response) { File.read("spec/fixtures/extras/journal_entry_#{entity_id}.json") }
+
+      subject { JournalEntry.new entity_id }
+
+      describe '#id' do
+        it 'shall be the expected id' do
+          expect(subject.id).to eq(entity_id)
+        end
+      end
+
+      describe '#comments' do
+        it 'should fetch the data' do
+          expect(faraday).to receive(:get).and_call_original
+
+          subject.comments
+        end
+
+        it 'shall be the expected comments' do
+          expect(subject.comments).to eq('Hello')
+        end
+      end
+
+      describe '.delete' do
+        let(:request_method) { :delete }
+        let(:response_status) { 204 }
+        let(:response) { nil }
+
+        it 'should delete the object' do
+          expect(faraday).to receive(request_method).and_call_original
+          subject.delete
+        end
+      end
+
+      describe '.update' do
+        let(:request_method) { :patch }
+        let(:request_params) { { 'comments' => 'Hi' } }
+
+        it 'should update the object' do
+          expect(faraday).to receive(request_method).and_call_original
+          expect(subject.update(comments: 'Hi').comments).to eq('Hello')
+        end
+      end
+
+      describe '.reload' do
+        it 'should reload the object' do
+          expect(faraday).to receive(request_method).twice.and_call_original
+
+          subject.reload
+          subject.reload
+        end
+      end
+
+      describe '.save' do
+        let(:comments) { 'foobar' }
+        let(:assigned_object_type) { 'dcim.device' }
+        let(:assigned_object_id) { 2 }
+        let(:request_params) do 
+          {
+            'comments' => comments,
+            'assigned_object_type' => assigned_object_type,
+            'assigned_object_id' => assigned_object_id
+          }
+        end
+
+        context 'update' do
+          let(:request_method) { :patch }
+
+          subject do
+            entity = JournalEntry.new entity_id
+            entity.comments = comments
+            entity.assigned_object_type = assigned_object_type
+            entity.assigned_object_id = assigned_object_id
+            entity
+          end
+
+          it 'does not call PATCH until save is called' do
+            expect(faraday).to_not receive(request_method)
+            expect(faraday).to_not receive(:get)
+
+            expect(subject.comments).to eq(comments)
+            expect(subject.assigned_object_type).to eq(assigned_object_type)
+            expect(subject.assigned_object_id).to eq(assigned_object_id)
+          end
+
+          it 'calls PATCH when save is called' do
+            expect(faraday).to receive(request_method).and_call_original
+
+            expect(subject.save).to be(subject)
+          end
+
+          it 'Reads the answer from the PATCH answer' do
+            expect(faraday).to receive(request_method).and_call_original
+
+            subject.save
+            expect(subject.comments).to eq('Hello')
+            expect(subject.assigned_object_type).to eq('dcim.device')
+            expect(subject.assigned_object_id).to eq(1)
+          end
+        end
+
+        context 'create' do
+          let(:request_method) { :post }
+          let(:request_url) { base_url }
+
+          subject do
+            entity = JournalEntry.new
+            entity.comments = comments
+            entity.assigned_object_type = assigned_object_type
+            entity.assigned_object_id = assigned_object_id
+            entity
+          end
+
+          it 'does not POST until save is called' do
+            expect(faraday).to_not receive(request_method)
+            expect(faraday).to_not receive(:get)
+
+            expect(subject.comments).to eq(comments)
+            expect(subject.assigned_object_type).to eq(assigned_object_type)
+            expect(subject.assigned_object_id).to eq(assigned_object_id)
+          end
+
+          it 'POSTs the data upon a call of save' do
+            expect(faraday).to receive(request_method).and_call_original
+
+            expect(subject.save).to be(subject)
+          end
+
+          it 'Reads the answer from the POST' do
+            expect(faraday).to receive(request_method).and_call_original
+
+            subject.save
+
+            expect(subject.id).to be(1)
+            expect(subject.comments).to eq('Hello')
+            expect(subject.assigned_object_type).to eq('dcim.device')
+            expect(subject.assigned_object_id).to eq(1)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/ninech/netbox-client-ruby/issues/47

Add basic Journal Entries functionality.

It is not returned with any objects in current API version (NetBox v 2.11.3). It has one relation with 'assigned_object' (that can be of any type, see fixtures) which doesn't seem to be useful at all, so omitting it for now.