### PR TITLE
Use new dry-configurable api 'default:'

### DIFF
--- a/lib/netbox_client_ruby.rb
+++ b/lib/netbox_client_ruby.rb
@@ -13,19 +13,19 @@ module NetboxClientRuby
       setting :rsa_private_key do
         # the default is intentionally not `~/.ssh/id_rsa`,
         # to not accidentally leak someone's main rsa private key
-        setting :path, '~/.ssh/netbox_rsa'
+        setting :path, default: '~/.ssh/netbox_rsa'
         setting :password
       end
     end
     setting :pagination do
-      setting :default_limit, 50
-      setting :max_limit, MAX_SIGNED_64BIT_INT
+      setting :default_limit, default: 50
+      setting :max_limit, default: MAX_SIGNED_64BIT_INT
     end
   end
 
   setting :faraday do
-    setting :adapter, :net_http
+    setting :adapter, default: :net_http
     setting :logger
-    setting :request_options, open_timeout: 1, timeout: 5
+    setting :request_options, default: { open_timeout: 1, timeout: 5 }
   end
 end


### PR DESCRIPTION
The `dry-configurable` gem has been updated with a new preferred API, it is now throwing deprecation warnings like this:

```
dry-configurable-0.13.0/lib/dry/configurable/dsl.rb:28:in `initialize' [dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
Provide a `default:` keyword argument instead
```

This pull-request implements the new syntax.