### PR TITLE
Allow using faraday 1.x

### DIFF
--- a/netbox-client-ruby.gemspec
+++ b/netbox-client-ruby.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_runtime_dependency 'dry-configurable', '~> 0.13.0'
-  spec.add_runtime_dependency 'faraday', '~> 0.11', '>= 0.11.0'
+  spec.add_runtime_dependency 'faraday', '>= 0.11.0', '< 2'
   spec.add_runtime_dependency 'faraday-detailed_logger', '~> 2.1'
-  spec.add_runtime_dependency 'faraday_middleware', '~> 0.11'
+  spec.add_runtime_dependency 'faraday_middleware', '>= 0.11', '< 2'
   spec.add_runtime_dependency 'ipaddress', '~> 0.8', '>= 0.8.3'
   spec.add_runtime_dependency 'openssl', '~> 2.0', '>= 2.0.5'
 

--- a/spec/netbox_client_ruby/connection_spec.rb
+++ b/spec/netbox_client_ruby/connection_spec.rb
@@ -45,8 +45,13 @@ describe NetboxClientRuby::Connection do
     end
 
     it 'sets the adapter' do
-      expect(NetboxClientRuby::Connection.new.builder.handlers)
-        .to include Faraday::Adapter::NetHttp
+      if Faraday::VERSION < '1.0'
+        expect(NetboxClientRuby::Connection.new.builder.handlers)
+          .to include Faraday::Adapter::NetHttp
+      else
+        expect(NetboxClientRuby::Connection.new.builder.adapter)
+          .to eq Faraday::Adapter::NetHttp
+      end
     end
 
     it 'adds the json middleware' do
@@ -65,8 +70,13 @@ describe NetboxClientRuby::Connection do
     end
 
     it 'sets the adapter' do
-      expect(NetboxClientRuby::Connection.new.builder.handlers)
-        .to include Faraday::Adapter::NetHttpPersistent
+      if Faraday::VERSION < '1.0'
+        expect(NetboxClientRuby::Connection.new.builder.handlers)
+          .to include Faraday::Adapter::NetHttpPersistent
+      else
+        expect(NetboxClientRuby::Connection.new.builder.adapter)
+          .to eq Faraday::Adapter::NetHttpPersistent
+      end
     end
   end
 


### PR DESCRIPTION
While version 2 is already out, this should at least unblock some use cases.

Fixes #57