### PR TITLE
Update version pin of dry-configurable and rake dependency

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: 3.2
     - name: Publish to RubyGems
       run: |
         mkdir -p $HOME/.gem

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: ["2.6", "2.7", "3.0"]
+        ruby: ["2.7", "3.0"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=2.3.4
+ARG RUBY_VERSION=3.2.2
 FROM ruby:${RUBY_VERSION}-alpine
 
 RUN apk add --no-cache git openssl-dev build-base

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,13 +4,13 @@ services:
     build:
       context: .
       args:
-        RUBY_VERSION: 2.3.4
-    image: netbox-client-ruby:2.3.4
+        RUBY_VERSION: 3.2.2
+    image: netbox-client-ruby:3.2.2
     command: 'docker/start.test.sh'
-  app24:
+  app27:
     build:
       context: .
       args:
-        RUBY_VERSION: 2.4.1
-    image: netbox-client-ruby:2.4.1
+        RUBY_VERSION: 2.7.8
+    image: netbox-client-ruby:2.7.8
     command: 'docker/start.test.sh'

--- a/netbox-client-ruby.gemspec
+++ b/netbox-client-ruby.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6.0'
 
-  spec.add_runtime_dependency 'dry-configurable', '~> 0.13.0'
+  spec.add_runtime_dependency 'dry-configurable', '~> 1.0'
   spec.add_runtime_dependency 'faraday', '>= 0.11.0', '< 2'
   spec.add_runtime_dependency 'faraday-detailed_logger', '~> 2.1'
   spec.add_runtime_dependency 'faraday_middleware', '>= 0.11', '< 2'

--- a/netbox-client-ruby.gemspec
+++ b/netbox-client-ruby.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6.0'
 
-  spec.add_runtime_dependency 'dry-configurable', '~> 1.0'
+  spec.add_runtime_dependency 'dry-configurable', '~> 1'
   spec.add_runtime_dependency 'faraday', '>= 0.11.0', '< 2'
   spec.add_runtime_dependency 'faraday-detailed_logger', '~> 2.1'
   spec.add_runtime_dependency 'faraday_middleware', '>= 0.11', '< 2'

--- a/netbox-client-ruby.gemspec
+++ b/netbox-client-ruby.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.add_runtime_dependency 'dry-configurable', '~> 1'
   spec.add_runtime_dependency 'faraday', '>= 0.11.0', '< 2'

--- a/netbox-client-ruby.gemspec
+++ b/netbox-client-ruby.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13'
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'rubocop', '~> 0.48'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.15'


### PR DESCRIPTION
Hello
First of all, thanks for this gem.

It would be great, if we could update the `dry-configurable` dependency to v1.x
1.0.0 was released back in November 2022 (the latest version 1.0.1 as well).

I have an app relying on version > 1 of the `dry-configurable` gem. I imagine that this is the case for other people's projects as well.

I have performed a limited number of tests of the `netbox-client-ruby` gem after updating the `dry-configurable` dependency but so far everything is working fine (fetching vm's, updating data etc.).

Kind regards.

-Severin