### PR TITLE
Add faraday matrix to CI

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -15,12 +15,23 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: ["2.7", "3.0"]
+        ruby: ['2.7', '3.0', '3.1', '3.2']
+        gemfile: ['gemfiles/faraday0.gemfile', 'gemfiles/faraday1.gemfile']
+        # Faraday 0.x with Ruby 3.x not supported
+        exclude:
+          - ruby: '3.0'
+            gemfile: gemfiles/faraday0.gemfile
+          - ruby: '3.1'
+            gemfile: gemfiles/faraday0.gemfile
+          - ruby: '3.2'
+            gemfile: gemfiles/faraday0.gemfile
     runs-on: ${{ matrix.os }}
+    env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
+      BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - run: bundle exec rake spec
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake spec

--- a/bin/setup
+++ b/bin/setup
@@ -5,4 +5,6 @@ set -vx
 
 bundle install
 
-# Do any other automated setup that you need to do here
+for filename in gemfiles/*.gemfile; do
+  BUNDLE_GEMFILE=$filename bundle install
+done

--- a/gemfiles/faraday0.gemfile
+++ b/gemfiles/faraday0.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "faraday", "= 0.11"
+gem "faraday_middleware", "< 1"
+
+gemspec path: ".."

--- a/gemfiles/faraday0.gemfile.lock
+++ b/gemfiles/faraday0.gemfile.lock
@@ -1,0 +1,95 @@
+PATH
+  remote: ..
+  specs:
+    netbox-client-ruby (0.9.0)
+      dry-configurable (~> 1)
+      faraday (>= 0.11.0, < 2)
+      faraday-detailed_logger (~> 2.1)
+      faraday_middleware (>= 0.11, < 2)
+      ipaddress (~> 0.8, >= 0.8.3)
+      openssl (>= 2.0.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.2.2)
+    diff-lcs (1.5.0)
+    dry-configurable (1.0.1)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-core (1.0.0)
+      concurrent-ruby (~> 1.0)
+      zeitwerk (~> 2.6)
+    faraday (0.11.0)
+      multipart-post (>= 1.2, < 3)
+    faraday-detailed_logger (2.4.0)
+      faraday (>= 0.8, < 2)
+      zeitwerk (~> 2.0)
+    faraday_middleware (0.14.0)
+      faraday (>= 0.7.4, < 1.0)
+    ipaddress (0.8.3)
+    method_source (1.0.0)
+    multipart-post (2.3.0)
+    openssl (3.2.0)
+    parallel (1.23.0)
+    parser (3.2.2.3)
+      ast (~> 2.4.1)
+      racc
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    racc (1.7.1)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.8.1)
+    rexml (3.2.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    rubocop (0.93.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
+      rexml
+      rubocop-ast (>= 0.6.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    rubocop-rspec (1.44.1)
+      rubocop (~> 0.87)
+      rubocop-ast (>= 0.7.1)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (1.8.0)
+    zeitwerk (2.6.12)
+
+PLATFORMS
+  arm64-darwin-22
+  x86_64-linux
+
+DEPENDENCIES
+  bundler (~> 2.1)
+  faraday (= 0.11)
+  faraday_middleware (< 1)
+  netbox-client-ruby!
+  pry (~> 0.10)
+  rake (~> 13)
+  rspec (~> 3.5)
+  rubocop (~> 0.48)
+  rubocop-rspec (~> 1.15)
+
+BUNDLED WITH
+   2.4.10

--- a/gemfiles/faraday1.gemfile
+++ b/gemfiles/faraday1.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "faraday", "= 1.0"
+gem "faraday_middleware", "< 2"
+
+gemspec path: ".."

--- a/gemfiles/faraday1.gemfile.lock
+++ b/gemfiles/faraday1.gemfile.lock
@@ -1,0 +1,94 @@
+PATH
+  remote: ..
+  specs:
+    netbox-client-ruby (0.9.0)
+      dry-configurable (~> 1)
+      faraday (>= 0.11.0, < 2)
+      faraday-detailed_logger (~> 2.1)
+      faraday_middleware (>= 0.11, < 2)
+      ipaddress (~> 0.8, >= 0.8.3)
+      openssl (>= 2.0.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.2.2)
+    diff-lcs (1.5.0)
+    dry-configurable (1.0.1)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-core (1.0.0)
+      concurrent-ruby (~> 1.0)
+      zeitwerk (~> 2.6)
+    faraday (1.0.0)
+      multipart-post (>= 1.2, < 3)
+    faraday-detailed_logger (2.5.0)
+      faraday (>= 0.16, < 3)
+    faraday_middleware (1.2.0)
+      faraday (~> 1.0)
+    ipaddress (0.8.3)
+    method_source (1.0.0)
+    multipart-post (2.3.0)
+    openssl (3.2.0)
+    parallel (1.23.0)
+    parser (3.2.2.3)
+      ast (~> 2.4.1)
+      racc
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    racc (1.7.1)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.8.1)
+    rexml (3.2.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    rubocop (0.93.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
+      rexml
+      rubocop-ast (>= 0.6.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    rubocop-rspec (1.44.1)
+      rubocop (~> 0.87)
+      rubocop-ast (>= 0.7.1)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (1.8.0)
+    zeitwerk (2.6.12)
+
+PLATFORMS
+  arm64-darwin-22
+  x86_64-linux
+
+DEPENDENCIES
+  bundler (~> 2.1)
+  faraday (= 1.0)
+  faraday_middleware (< 2)
+  netbox-client-ruby!
+  pry (~> 0.10)
+  rake (~> 13)
+  rspec (~> 3.5)
+  rubocop (~> 0.48)
+  rubocop-rspec (~> 1.15)
+
+BUNDLED WITH
+   2.4.10

--- a/spec/netbox_client_ruby/connection_spec.rb
+++ b/spec/netbox_client_ruby/connection_spec.rb
@@ -97,19 +97,29 @@ describe NetboxClientRuby::Connection do
       end
     end
 
-    context 'detailed logger' do
-      before do
-        NetboxClientRuby.configure do |config|
-          config.netbox.auth.token = '2e35594ec8710e9922d14365a1ea66f27ea69450'
-          config.netbox.api_base_url = 'https://netbox.test/api/'
-          config.faraday.logger = :detailed_logger
-          config.faraday.adapter = :net_http
+    # For old versions of Faraday prior to Faraday 0.16.x, it does not appear to
+    # be possible to set the current version of faraday-detailed_logger, which raises the error
+    #
+    #  Faraday::Error:
+    #      :detailed_logger is not registered on Faraday::Response
+    #
+    # Because this version range of Faraday is so old, we skip the test rather
+    # than attempting to backport this optional feature.
+    if Faraday::VERSION > '0.16'
+      context 'detailed logger' do
+        before do
+          NetboxClientRuby.configure do |config|
+            config.netbox.auth.token = '2e35594ec8710e9922d14365a1ea66f27ea69450'
+            config.netbox.api_base_url = 'https://netbox.test/api/'
+            config.faraday.logger = :detailed_logger
+            config.faraday.adapter = :net_http
+          end
         end
-      end
 
-      it 'sets the logger' do
-        expect(NetboxClientRuby::Connection.new.builder.handlers)
-          .to include Faraday::DetailedLogger::Middleware
+        it 'sets the logger' do
+          expect(NetboxClientRuby::Connection.new.builder.handlers)
+            .to include Faraday::DetailedLogger::Middleware
+        end
       end
     end
   end


### PR DESCRIPTION
## Problem

`netbox-client-ruby` supports Faraday 0.11.x up to 1.x. Faraday 2 has been out since Jan 2022. There are some incompatibilities across this range of Faraday versions, e.g. Faraday 0.x does not appear to work with Ruby 3.x. Only Faraday 1.x is tested on CI and there is not currently a strategy to test multiple Faraday versions.

## Solution

Adopt a Gemfile matrix for CI to test multiple versions of Faraday against multiple versions of Ruby from 2.7-3.2.

This change adds additional gemfiles in the gemfiles/ directory for exercising tests against the minimum supported version of Faraday 0.11 and the most recent supported Faraday 1.x version. This also enables change I have in progress to add support for Faraday 2.x https://github.com/rossta/netbox-client-ruby/compare/chore/faraday-matrix...rossta:netbox-client-ruby:feat/faraday-2-support.

Now `bin/setup` will install gems for each gemfile and the current Ruby.

To run tests against Faraday 0.x for example, one would run:

```
BUNDLE_GEMFILE=gemfile/faraday0.gemfile bundle exec rspec
```