### PR TITLE
Reset config changes before each test

### DIFF
--- a/spec/shared_contexts/netbox_client.rb
+++ b/spec/shared_contexts/netbox_client.rb
@@ -1,3 +1,10 @@
+require "dry/configurable/test_interface"
+
+# https://dry-rb.org/gems/dry-configurable/1.0/testing/
+module NetboxClientRuby
+  enable_test_interface
+end
+
 RSpec.shared_context 'connection setup' do
   let(:netbox_auth_token) { 'this-is-the-test-token' }
   let(:netbox_api_base_url) { 'http://netbox.test/api/' }
@@ -5,6 +12,7 @@ RSpec.shared_context 'connection setup' do
   let(:netbox_auth_rsa_private_key_pass) { nil }
 
   before do
+    NetboxClientRuby.reset_config
     NetboxClientRuby.configure do |config|
       config.netbox.auth.token = netbox_auth_token
       config.netbox.auth.rsa_private_key.path = netbox_auth_rsa_private_key_file


### PR DESCRIPTION
## Problem

While running tests locally with Ruby 3+, the logger sometimes outputs to $stdout which creates noisy test output. 

To reproduce, run tests on Ruby 3.2 with `bundle exec rspec --seed 27884`: 

```ruby
$ be rspec --seed 27884

.............................................................................................................................................................................I, [2023-09-27T21:55:31.949858 #79021]  INFO -- request: GET http://netbox.test/api/virtualization/clusters.json?limit=42
I, [2023-09-27T21:55:31.949909 #79021]  INFO -- request: Authorization: "Token this-is-the-test-token"
User-Agent: "Faraday v1.10.3"
...I, [2023-09-27T21:55:31.957737 #79021]  INFO -- request: GET http://netbox.test/api/virtualization/cluster-types/1.json
I, [2023-09-27T21:55:31.957763 #79021]  INFO -- request: Authorization: "Token this-is-the-test-token"
User-Agent: "Faraday v1.10.3"
....I, [2023-09-27T21:55:31.964715 #79021]  INFO -- request: GET http://netbox.test/api/virtualization/virtual-machines.json?limit=42
I, [2023-09-27T21:55:31.964739 #79021]  INFO -- request: Authorization: "Token this-is-the-test-token"
User-Agent: "Faraday v1.10.3"
....

(etc)
```

The issue does not occur when tests are run on Ruby 3.2 with `bundle exec rspec --seed 61562`. 


## Solution

The root cause is from modifying the global configuration via `NetboxClientRuby.configure` in `connection_spec.rb` and `netbox_spec.rb`. These tests set a "logger" which bleeds over to other tests that are run after. Other configuration settings bleed over as well though their effect isn't observed.

The fix here is to reset all config changes before each test using the testing interface provided by `Dry::Configurable`. This change ensures that global configuration modifications from one test don't bleed into other tests.

https://dry-rb.org/gems/dry-configurable/1.0/testing/