### PR TITLE
fix: remove .json suffix from entity requests

### DIFF
--- a/lib/netbox_client_ruby/api/circuits/circuit.rb
+++ b/lib/netbox_client_ruby/api/circuits/circuit.rb
@@ -16,7 +16,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'circuits/circuits/:id.json'
+      path 'circuits/circuits/:id/'
       creation_path 'circuits/circuits/'
 
       object_fields(

--- a/lib/netbox_client_ruby/api/circuits/circuit_termination.rb
+++ b/lib/netbox_client_ruby/api/circuits/circuit_termination.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'circuits/circuit-terminations/:id.json'
+      path 'circuits/circuit-terminations/:id/'
       creation_path 'circuits/circuit-terminations/'
 
       object_fields(

--- a/lib/netbox_client_ruby/api/circuits/circuit_type.rb
+++ b/lib/netbox_client_ruby/api/circuits/circuit_type.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'circuits/circuit-types/:id.json'
+      path 'circuits/circuit-types/:id/'
       creation_path 'circuits/circuit-types/'
     end
   end

--- a/lib/netbox_client_ruby/api/circuits/provider.rb
+++ b/lib/netbox_client_ruby/api/circuits/provider.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'circuits/providers/:id.json'
+      path 'circuits/providers/:id/'
       creation_path 'circuits/providers/'
     end
   end

--- a/lib/netbox_client_ruby/api/dcim/console_connection.rb
+++ b/lib/netbox_client_ruby/api/dcim/console_connection.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/console-connections/:id.json'
+      path 'dcim/console-connections/:id/'
       creation_path 'dcim/console-connections/'
 
       object_fields(

--- a/lib/netbox_client_ruby/api/dcim/console_port.rb
+++ b/lib/netbox_client_ruby/api/dcim/console_port.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/console-ports/:id.json'
+      path 'dcim/console-ports/:id/'
       creation_path 'dcim/console-ports/'
 
       object_fields(

--- a/lib/netbox_client_ruby/api/dcim/console_server_port.rb
+++ b/lib/netbox_client_ruby/api/dcim/console_server_port.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/console-server-ports/:id.json'
+      path 'dcim/console-server-ports/:id/'
       creation_path 'dcim/console-server-ports/'
 
       object_fields(

--- a/lib/netbox_client_ruby/api/dcim/device.rb
+++ b/lib/netbox_client_ruby/api/dcim/device.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/devices/:id.json'
+      path 'dcim/devices/:id/'
       creation_path 'dcim/devices/'
       object_fields(
         device_type: proc { |raw_data| DeviceType.new raw_data['id'] },

--- a/lib/netbox_client_ruby/api/dcim/device_role.rb
+++ b/lib/netbox_client_ruby/api/dcim/device_role.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/device-roles/:id.json'
+      path 'dcim/device-roles/:id/'
       creation_path 'dcim/device-roles/'
     end
   end

--- a/lib/netbox_client_ruby/api/dcim/device_type.rb
+++ b/lib/netbox_client_ruby/api/dcim/device_type.rb
@@ -16,7 +16,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/device-types/:id.json'
+      path 'dcim/device-types/:id/'
       creation_path 'dcim/device-types/'
       object_fields(
         manufacturer: proc { |raw_data| Manufacturer.new raw_data['id'] },

--- a/lib/netbox_client_ruby/api/dcim/interface.rb
+++ b/lib/netbox_client_ruby/api/dcim/interface.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/interfaces/:id.json'
+      path 'dcim/interfaces/:id/'
       creation_path 'dcim/interfaces/'
       object_fields device: proc { |raw_data| Device.new raw_data['id'] }
     end

--- a/lib/netbox_client_ruby/api/dcim/interface_connection.rb
+++ b/lib/netbox_client_ruby/api/dcim/interface_connection.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/interface-connections/:id.json'
+      path 'dcim/interface-connections/:id/'
       creation_path 'dcim/interface-connections/'
 
       object_fields(

--- a/lib/netbox_client_ruby/api/dcim/inventory_item.rb
+++ b/lib/netbox_client_ruby/api/dcim/inventory_item.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/inventory-items/:id.json'
+      path 'dcim/inventory-items/:id/'
       creation_path 'dcim/inventory-items/'
       object_fields device: proc { |raw_data| Device.new raw_data['id'] },
                     manufacturer: proc { |raw_data| Manufacturer.new raw_data['id'] }

--- a/lib/netbox_client_ruby/api/dcim/manufacturer.rb
+++ b/lib/netbox_client_ruby/api/dcim/manufacturer.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/manufacturers/:id.json'
+      path 'dcim/manufacturers/:id/'
       creation_path 'dcim/manufacturers/'
     end
   end

--- a/lib/netbox_client_ruby/api/dcim/platform.rb
+++ b/lib/netbox_client_ruby/api/dcim/platform.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/platforms/:id.json'
+      path 'dcim/platforms/:id/'
       creation_path 'dcim/platforms/'
       object_fields(
         manufacturer: proc do |raw_manufacturer|

--- a/lib/netbox_client_ruby/api/dcim/power_connection.rb
+++ b/lib/netbox_client_ruby/api/dcim/power_connection.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/power-connections/:id.json'
+      path 'dcim/power-connections/:id/'
       creation_path 'dcim/power-connections/'
 
       object_fields(

--- a/lib/netbox_client_ruby/api/dcim/power_outlet.rb
+++ b/lib/netbox_client_ruby/api/dcim/power_outlet.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/power-outlets/:id.json'
+      path 'dcim/power-outlets/:id/'
       creation_path 'dcim/power-outlets/'
       object_fields device: proc { |raw_data| Device.new raw_data['id'] }
       object_fields connected_port: proc { |raw_data| PowerPort.new raw_data }

--- a/lib/netbox_client_ruby/api/dcim/power_port.rb
+++ b/lib/netbox_client_ruby/api/dcim/power_port.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/power-ports/:id.json'
+      path 'dcim/power-ports/:id/'
       creation_path 'dcim/power-ports/'
       object_fields device: proc { |raw_data| Device.new raw_data['id'] }
       object_fields power_outlet: proc { |raw_data| PowerOutlet.new raw_data['id'] }

--- a/lib/netbox_client_ruby/api/dcim/rack.rb
+++ b/lib/netbox_client_ruby/api/dcim/rack.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/racks/:id.json'
+      path 'dcim/racks/:id/'
       creation_path 'dcim/racks/'
     end
   end

--- a/lib/netbox_client_ruby/api/dcim/rack_group.rb
+++ b/lib/netbox_client_ruby/api/dcim/rack_group.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/rack-groups/:id.json'
+      path 'dcim/rack-groups/:id/'
       creation_path 'dcim/rack-groups/'
       object_fields(
         region: proc { |raw_data| DCIM::Region.new raw_data['id'] },

--- a/lib/netbox_client_ruby/api/dcim/rack_reservation.rb
+++ b/lib/netbox_client_ruby/api/dcim/rack_reservation.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/rack-reservations/:id.json'
+      path 'dcim/rack-reservations/:id/'
       creation_path 'dcim/rack-reservations/'
 
       object_fields(

--- a/lib/netbox_client_ruby/api/dcim/rack_role.rb
+++ b/lib/netbox_client_ruby/api/dcim/rack_role.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/rack-roles/:id.json'
+      path 'dcim/rack-roles/:id/'
       creation_path 'dcim/rack-roles/'
     end
   end

--- a/lib/netbox_client_ruby/api/dcim/region.rb
+++ b/lib/netbox_client_ruby/api/dcim/region.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/regions/:id.json'
+      path 'dcim/regions/:id/'
       creation_path 'dcim/regions/'
       object_fields parent: proc { |raw_data| Region.new raw_data['id'] }
     end

--- a/lib/netbox_client_ruby/api/dcim/site.rb
+++ b/lib/netbox_client_ruby/api/dcim/site.rb
@@ -16,7 +16,7 @@ module NetboxClientRuby
                       :count_devices, :count_circuits
 
       deletable true
-      path 'dcim/sites/:id.json'
+      path 'dcim/sites/:id/'
       creation_path 'dcim/sites/'
       object_fields(
         region: proc { |raw_region| DCIM::Region.new raw_region['id'] },

--- a/lib/netbox_client_ruby/api/dcim/virtual_chassis.rb
+++ b/lib/netbox_client_ruby/api/dcim/virtual_chassis.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'dcim/virtual-chassis/:id.json'
+      path 'dcim/virtual-chassis/:id/'
       creation_path 'dcim/virtual-chassis/'
 
       object_fields(

--- a/lib/netbox_client_ruby/api/extras/config_context.rb
+++ b/lib/netbox_client_ruby/api/extras/config_context.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'extras/config-contexts/:id.json'
+      path 'extras/config-contexts/:id/'
       creation_path 'extras/config-contexts/'
       object_fields(
         regions: proc { |raw_data| DCIM::Region.new raw_data['id'] },

--- a/lib/netbox_client_ruby/api/extras/journal_entry.rb
+++ b/lib/netbox_client_ruby/api/extras/journal_entry.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'extras/journal-entries/:id.json'
+      path 'extras/journal-entries/:id/'
       creation_path 'extras/journal-entries/'
     end
   end

--- a/lib/netbox_client_ruby/api/extras/tag.rb
+++ b/lib/netbox_client_ruby/api/extras/tag.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'extras/tags/:id.json'
+      path 'extras/tags/:id/'
       creation_path 'extras/tags/'
     end
   end

--- a/lib/netbox_client_ruby/api/ipam/aggregate.rb
+++ b/lib/netbox_client_ruby/api/ipam/aggregate.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'ipam/aggregates/:id.json'
+      path 'ipam/aggregates/:id/'
       creation_path 'ipam/aggregates/'
       object_fields rir: proc { |raw_data| Rir.new raw_data['id'] }
     end

--- a/lib/netbox_client_ruby/api/ipam/ip_address.rb
+++ b/lib/netbox_client_ruby/api/ipam/ip_address.rb
@@ -14,7 +14,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'ipam/ip-addresses/:id.json'
+      path 'ipam/ip-addresses/:id/'
       creation_path 'ipam/ip-addresses/'
       object_fields(
         vrf: proc { |raw_data| Vrf.new raw_data['id'] },

--- a/lib/netbox_client_ruby/api/ipam/ip_range.rb
+++ b/lib/netbox_client_ruby/api/ipam/ip_range.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'ipam/ip-ranges/:id.json'
+      path 'ipam/ip-ranges/:id/'
       creation_path 'ipam/ip-ranges/'
       object_fields(
         vrf: proc { |raw_data| Vrf.new raw_data['id'] },

--- a/lib/netbox_client_ruby/api/ipam/prefix.rb
+++ b/lib/netbox_client_ruby/api/ipam/prefix.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'ipam/prefixes/:id.json'
+      path 'ipam/prefixes/:id/'
       creation_path 'ipam/prefixes/'
       object_fields(
         site: proc { |raw_data| DCIM::Site.new raw_data['id'] },

--- a/lib/netbox_client_ruby/api/ipam/rir.rb
+++ b/lib/netbox_client_ruby/api/ipam/rir.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'ipam/rirs/:id.json'
+      path 'ipam/rirs/:id/'
       creation_path 'ipam/rirs/'
     end
   end

--- a/lib/netbox_client_ruby/api/ipam/role.rb
+++ b/lib/netbox_client_ruby/api/ipam/role.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'ipam/roles/:id.json'
+      path 'ipam/roles/:id/'
       creation_path 'ipam/roles/'
     end
   end

--- a/lib/netbox_client_ruby/api/ipam/service.rb
+++ b/lib/netbox_client_ruby/api/ipam/service.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'ipam/services/:id.json'
+      path 'ipam/services/:id/'
       creation_path 'ipam/services/'
       object_fields(
         device: proc { |raw_data| Device.new raw_data['id'] },

--- a/lib/netbox_client_ruby/api/ipam/vlan.rb
+++ b/lib/netbox_client_ruby/api/ipam/vlan.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'ipam/vlans/:id.json'
+      path 'ipam/vlans/:id/'
       creation_path 'ipam/vlans/'
       object_fields(
         tenant: proc { |raw_data| Tenancy::Tenant.new raw_data['id'] },

--- a/lib/netbox_client_ruby/api/ipam/vlan_group.rb
+++ b/lib/netbox_client_ruby/api/ipam/vlan_group.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'ipam/vlan-groups/:id.json'
+      path 'ipam/vlan-groups/:id/'
       creation_path 'ipam/vlan-groups/'
       object_fields site: proc { |raw_data| DCIM::Site.new raw_data['id'] }
     end

--- a/lib/netbox_client_ruby/api/ipam/vrf.rb
+++ b/lib/netbox_client_ruby/api/ipam/vrf.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'ipam/vrfs/:id.json'
+      path 'ipam/vrfs/:id/'
       creation_path 'ipam/vrfs/'
       object_fields tenant: proc { |raw_data| Tenancy::Tenant.new raw_data['id'] }
     end

--- a/lib/netbox_client_ruby/api/secrets/secret.rb
+++ b/lib/netbox_client_ruby/api/secrets/secret.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'secrets/secrets/:id.json'
+      path 'secrets/secrets/:id/'
       creation_path 'secrets/secrets/'
       object_fields device: proc { |raw_data| Device.new raw_data['id'] },
                     role: proc { |raw_data| SecretRole.new raw_data['id'] }

--- a/lib/netbox_client_ruby/api/secrets/secret_role.rb
+++ b/lib/netbox_client_ruby/api/secrets/secret_role.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'secrets/secret-roles/:id.json'
+      path 'secrets/secret-roles/:id/'
       creation_path 'secrets/secret-roles/'
     end
   end

--- a/lib/netbox_client_ruby/api/tenancy/tenant.rb
+++ b/lib/netbox_client_ruby/api/tenancy/tenant.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'tenancy/tenants/:id.json'
+      path 'tenancy/tenants/:id/'
       creation_path 'tenancy/tenants/'
       object_fields group: proc { |raw_data| TenantGroup.new raw_data['id'] }
     end

--- a/lib/netbox_client_ruby/api/tenancy/tenant_group.rb
+++ b/lib/netbox_client_ruby/api/tenancy/tenant_group.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'tenancy/tenant-groups/:id.json'
+      path 'tenancy/tenant-groups/:id/'
       creation_path 'tenancy/tenant-groups/'
     end
   end

--- a/lib/netbox_client_ruby/api/virtualization/cluster.rb
+++ b/lib/netbox_client_ruby/api/virtualization/cluster.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'virtualization/clusters/:id.json'
+      path 'virtualization/clusters/:id/'
       creation_path 'virtualization/clusters/'
       object_fields(
         group: proc { |raw_data| ClusterGroup.new raw_data['id'] },

--- a/lib/netbox_client_ruby/api/virtualization/cluster_group.rb
+++ b/lib/netbox_client_ruby/api/virtualization/cluster_group.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'virtualization/cluster-groups/:id.json'
+      path 'virtualization/cluster-groups/:id/'
       creation_path 'virtualization/cluster-groups/'
     end
   end

--- a/lib/netbox_client_ruby/api/virtualization/cluster_type.rb
+++ b/lib/netbox_client_ruby/api/virtualization/cluster_type.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'virtualization/cluster-types/:id.json'
+      path 'virtualization/cluster-types/:id/'
       creation_path 'virtualization/cluster-types/'
     end
   end

--- a/lib/netbox_client_ruby/api/virtualization/interface.rb
+++ b/lib/netbox_client_ruby/api/virtualization/interface.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'virtualization/interfaces/:id.json'
+      path 'virtualization/interfaces/:id/'
       creation_path 'virtualization/interfaces/'
       object_fields virtual_machine: proc { |raw_data|
         VirtualMachine.new raw_data['id']

--- a/lib/netbox_client_ruby/api/virtualization/virtual_machine.rb
+++ b/lib/netbox_client_ruby/api/virtualization/virtual_machine.rb
@@ -7,7 +7,7 @@ module NetboxClientRuby
 
       id id: :id
       deletable true
-      path 'virtualization/virtual-machines/:id.json'
+      path 'virtualization/virtual-machines/:id/'
       creation_path 'virtualization/virtual-machines/'
       object_fields(
         cluster: proc { |raw_data| Cluster.new raw_data['id'] },

--- a/spec/netbox_client_ruby/api/circuits/circuit_spec.rb
+++ b/spec/netbox_client_ruby/api/circuits/circuit_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::Circuits::Circuit, faraday_stub: true do
   let(:id) { 1 }
   let(:base_url) { '/api/circuits/circuits/' }
-  let(:request_url) { "#{base_url}#{id}.json" }
+  let(:request_url) { "#{base_url}#{id}/" }
   let(:response) { File.read("spec/fixtures/circuits/circuit_#{id}.json") }
 
   subject { described_class.new id }

--- a/spec/netbox_client_ruby/api/circuits/circuit_termination_spec.rb
+++ b/spec/netbox_client_ruby/api/circuits/circuit_termination_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::Circuits::CircuitTermination, faraday_stub: true do
   let(:id) { 1 }
   let(:base_url) { '/api/circuits/circuit-terminations/' }
-  let(:request_url) { "#{base_url}#{id}.json" }
+  let(:request_url) { "#{base_url}#{id}/" }
   let(:response) { File.read("spec/fixtures/circuits/circuit-termination_#{id}.json") }
 
   subject { described_class.new id }

--- a/spec/netbox_client_ruby/api/circuits/circuit_type_spec.rb
+++ b/spec/netbox_client_ruby/api/circuits/circuit_type_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::Circuits::CircuitType, faraday_stub: true do
   let(:id) { 1 }
   let(:base_url) { '/api/circuits/circuit-types/' }
-  let(:request_url) { "#{base_url}#{id}.json" }
+  let(:request_url) { "#{base_url}#{id}/" }
   let(:response) { File.read("spec/fixtures/circuits/circuit-type_#{id}.json") }
 
   subject { described_class.new id }

--- a/spec/netbox_client_ruby/api/circuits/provider_spec.rb
+++ b/spec/netbox_client_ruby/api/circuits/provider_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::Circuits::Provider, faraday_stub: true do
   let(:id) { 1 }
   let(:base_url) { '/api/circuits/providers/' }
-  let(:request_url) { "#{base_url}#{id}.json" }
+  let(:request_url) { "#{base_url}#{id}/" }
   let(:response) { File.read("spec/fixtures/circuits/provider_#{id}.json") }
 
   subject { described_class.new id }

--- a/spec/netbox_client_ruby/api/dcim/console_connection_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/console_connection_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::ConsoleConnection, faraday_stub: true do
   let(:base_url) { '/api/dcim/console-connections/' }
   let(:response) { File.read("spec/fixtures/dcim/console-connection_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/dcim/console_port_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/console_port_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::ConsolePort, faraday_stub: true do
   let(:base_url) { '/api/dcim/console-ports/' }
   let(:response) { File.read("spec/fixtures/dcim/console-port_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/dcim/console_server_port_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/console_server_port_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::ConsoleServerPort, faraday_stub: true do
   let(:base_url) { '/api/dcim/console-server-ports/' }
   let(:response) { File.read("spec/fixtures/dcim/console-server-port_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/dcim/device_role_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/device_role_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::DeviceRole, faraday_stub: true do
   let(:sut) { NetboxClientRuby::DCIM::DeviceRole }
   let(:base_url) { '/api/dcim/device-roles/' }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
   let(:response) { File.read("spec/fixtures/dcim/device-role_#{entity_id}.json") }
 
   subject { sut.new entity_id }

--- a/spec/netbox_client_ruby/api/dcim/device_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/device_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NetboxClientRuby::DCIM::Device, faraday_stub: true do
   let(:base_url) { '/api/dcim/devices/' }
   let(:response) { File.read("spec/fixtures/dcim/device_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { sut.new entity_id }
 

--- a/spec/netbox_client_ruby/api/dcim/device_type_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/device_type_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::DeviceType, faraday_stub: true do
   let(:sut) { NetboxClientRuby::DCIM::DeviceType }
   let(:base_url) { '/api/dcim/device-types/' }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
   let(:response) { File.read("spec/fixtures/dcim/device-type_#{entity_id}.json") }
 
   subject { sut.new entity_id }

--- a/spec/netbox_client_ruby/api/dcim/interface_connection_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/interface_connection_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::InterfaceConnection, faraday_stub: true d
   let(:base_url) { '/api/dcim/interface-connections/' }
   let(:response) { File.read("spec/fixtures/dcim/interface-connection_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/dcim/interface_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/interface_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::Interface, faraday_stub: true do
   let(:sut) { NetboxClientRuby::DCIM::Interface }
   let(:base_url) { '/api/dcim/interfaces/' }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
   let(:response) { File.read("spec/fixtures/dcim/interface_#{entity_id}.json") }
 
   subject { sut.new entity_id }

--- a/spec/netbox_client_ruby/api/dcim/inventory_item_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/inventory_item_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::InventoryItem, faraday_stub: true do
   let(:sut) { NetboxClientRuby::DCIM::InventoryItem }
   let(:base_url) { '/api/dcim/inventory-items/' }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
   let(:response) { File.read("spec/fixtures/dcim/inventory-item_#{entity_id}.json") }
 
   subject { sut.new entity_id }

--- a/spec/netbox_client_ruby/api/dcim/manufacturer_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/manufacturer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe NetboxClientRuby::DCIM::Manufacturer, faraday_stub: true do
   let(:expected_name) { 'manu1' }
   let(:sut) { NetboxClientRuby::DCIM::Manufacturer }
   let(:base_url) { '/api/dcim/manufacturers/' }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
   let(:response) { File.read("spec/fixtures/dcim/manufacturer_#{entity_id}.json") }
 
   subject { sut.new entity_id }

--- a/spec/netbox_client_ruby/api/dcim/platform_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/platform_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::Platform, faraday_stub: true do
   let(:sut) { NetboxClientRuby::DCIM::Platform }
   let(:base_url) { '/api/dcim/platforms/' }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
   let(:response) { File.read("spec/fixtures/dcim/platform_#{entity_id}.json") }
 
   subject { sut.new entity_id }

--- a/spec/netbox_client_ruby/api/dcim/power_connection_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/power_connection_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::PowerConnection, faraday_stub: true do
   let(:base_url) { '/api/dcim/power-connections/' }
   let(:response) { File.read("spec/fixtures/dcim/power-connection_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/dcim/power_outlet_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/power_outlet_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe NetboxClientRuby::DCIM::PowerOutlet, faraday_stub: true do
   let(:expected_name) { '3' }
   let(:base_url) { '/api/dcim/power-outlets/' }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
   let(:response) { File.read("spec/fixtures/dcim/power-outlets_#{entity_id}.json") }
 
   subject { described_class.new entity_id }

--- a/spec/netbox_client_ruby/api/dcim/power_port_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/power_port_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe NetboxClientRuby::DCIM::PowerPort, faraday_stub: true do
   let(:expected_name) { 'psu1' }
   let(:base_url) { '/api/dcim/power-ports/' }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
   let(:response) { File.read("spec/fixtures/dcim/power-ports_#{entity_id}.json") }
 
   subject { described_class.new entity_id }

--- a/spec/netbox_client_ruby/api/dcim/rack_group_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/rack_group_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::RackGroup, faraday_stub: true do
   let(:base_url) { '/api/dcim/rack-groups/' }
   let(:response) { File.read("spec/fixtures/dcim/rack-group_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/dcim/rack_reservation_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/rack_reservation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::RackReservation, faraday_stub: true do
   let(:base_url) { '/api/dcim/rack-reservations/' }
   let(:response) { File.read("spec/fixtures/dcim/rack-reservation_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/dcim/rack_role_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/rack_role_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::RackRole, faraday_stub: true do
   let(:base_url) { '/api/dcim/rack-roles/' }
   let(:response) { File.read("spec/fixtures/dcim/rack-role_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/dcim/rack_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/rack_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NetboxClientRuby::DCIM::Rack, faraday_stub: true do
   let(:base_url) { '/api/dcim/racks/' }
   let(:response) { File.read("spec/fixtures/dcim/rack_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { sut.new entity_id }
 

--- a/spec/netbox_client_ruby/api/dcim/region_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/region_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::DCIM::Region, faraday_stub: true do
   let(:region_id) { 1 }
   let(:response) { File.read("spec/fixtures/dcim/region_#{region_id}.json") }
-  let(:request_url) { "/api/dcim/regions/#{region_id}.json" }
+  let(:request_url) { "/api/dcim/regions/#{region_id}/" }
 
   subject { NetboxClientRuby::DCIM::Region.new region_id }
 

--- a/spec/netbox_client_ruby/api/dcim/site_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/site_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::DCIM::Site, faraday_stub: true do
   let(:site_id) { 1 }
   let(:response) { File.read("spec/fixtures/dcim/site_#{site_id}.json") }
-  let(:request_url) { "/api/dcim/sites/#{site_id}.json" }
+  let(:request_url) { "/api/dcim/sites/#{site_id}/" }
 
   subject { NetboxClientRuby::DCIM::Site.new site_id }
 

--- a/spec/netbox_client_ruby/api/dcim/virtual_chassis_spec.rb
+++ b/spec/netbox_client_ruby/api/dcim/virtual_chassis_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::DCIM::VirtualChassis, faraday_stub: true do
   let(:base_url) { '/api/dcim/virtual-chassis/' }
   let(:response) { File.read("spec/fixtures/dcim/virtual-chassis_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/extras/config_context_spec.rb
+++ b/spec/netbox_client_ruby/api/extras/config_context_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::Extras::ConfigContext, faraday_stub: true do
   let(:entity_id) { 1 }
   let(:base_url) { '/api/extras/config-contexts/' }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
   let(:response) { File.read("spec/fixtures/extras/config_context_#{entity_id}.json") }
 
   subject { NetboxClientRuby::Extras::ConfigContext.new entity_id }

--- a/spec/netbox_client_ruby/api/extras/journal_entry_spec.rb
+++ b/spec/netbox_client_ruby/api/extras/journal_entry_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::Extras::JournalEntry, faraday_stub: true do
   let(:entity_id) { 1 }
   let(:base_url) { '/api/extras/journal-entries/' }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
   let(:response) { File.read("spec/fixtures/extras/journal_entry_#{entity_id}.json") }
 
   subject { NetboxClientRuby::Extras::JournalEntry.new entity_id }

--- a/spec/netbox_client_ruby/api/extras/tag_spec.rb
+++ b/spec/netbox_client_ruby/api/extras/tag_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::Extras::Tag, faraday_stub: true do
   let(:entity_id) { 1 }
   let(:base_url) { '/api/extras/tags/' }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
   let(:response) { File.read("spec/fixtures/extras/tag_#{entity_id}.json") }
 
   subject { NetboxClientRuby::Extras::Tag.new entity_id }

--- a/spec/netbox_client_ruby/api/ipam/aggregate_spec.rb
+++ b/spec/netbox_client_ruby/api/ipam/aggregate_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NetboxClientRuby::IPAM::Aggregate, faraday_stub: true do
 
   let(:expected_prefix) { '10.0.0.0/8' }
   let(:entity_id) { 1 }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { class_under_test.new entity_id }
 

--- a/spec/netbox_client_ruby/api/ipam/ip_address_spec.rb
+++ b/spec/netbox_client_ruby/api/ipam/ip_address_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe NetboxClientRuby::IPAM::IpAddress, faraday_stub: true do
 
   let(:expected_address) { IPAddress.parse('10.0.0.1/8') }
   let(:entity_id) { 1 }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { class_under_test.new entity_id }
 

--- a/spec/netbox_client_ruby/api/ipam/ip_range_spec.rb
+++ b/spec/netbox_client_ruby/api/ipam/ip_range_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe NetboxClientRuby::IPAM::IpRange, faraday_stub: true do
   let(:expected_start_address) { IPAddress.parse '10.2.0.10/16' }
   let(:expected_end_address) { IPAddress.parse '10.2.0.20/16' }
   let(:entity_id) { 3 }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { class_under_test.new entity_id }
 

--- a/spec/netbox_client_ruby/api/ipam/prefix_spec.rb
+++ b/spec/netbox_client_ruby/api/ipam/prefix_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe NetboxClientRuby::IPAM::Prefix, faraday_stub: true do
 
   let(:expected_prefix) { IPAddress.parse '10.2.0.0/16' }
   let(:entity_id) { 3 }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { class_under_test.new entity_id }
 

--- a/spec/netbox_client_ruby/api/ipam/rir_spec.rb
+++ b/spec/netbox_client_ruby/api/ipam/rir_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NetboxClientRuby::IPAM::Rir, faraday_stub: true do
   let(:response) { File.read("spec/fixtures/ipam/rir_#{entity_id}.json") }
 
   let(:entity_id) { 1 }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { class_under_test.new entity_id }
 

--- a/spec/netbox_client_ruby/api/ipam/role_spec.rb
+++ b/spec/netbox_client_ruby/api/ipam/role_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NetboxClientRuby::IPAM::Role, faraday_stub: true do
   let(:response) { File.read("spec/fixtures/ipam/role_#{entity_id}.json") }
 
   let(:entity_id) { 1 }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { NetboxClientRuby::IPAM::Role.new entity_id }
 

--- a/spec/netbox_client_ruby/api/ipam/service_spec.rb
+++ b/spec/netbox_client_ruby/api/ipam/service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::IPAM::Service, faraday_stub: true do
   let(:response) { File.read("spec/fixtures/ipam/service_#{entity_id}.json") }
 
   let(:entity_id) { 1 }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { NetboxClientRuby::IPAM::Service.new entity_id }
 

--- a/spec/netbox_client_ruby/api/ipam/vlan_group_spec.rb
+++ b/spec/netbox_client_ruby/api/ipam/vlan_group_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe NetboxClientRuby::IPAM::VlanGroup, faraday_stub: true do
   let(:response) { File.read("spec/fixtures/ipam/vlan-group_#{entity_id}.json") }
 
   let(:entity_id) { 1 }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { class_under_test.new entity_id }
 

--- a/spec/netbox_client_ruby/api/ipam/vlan_spec.rb
+++ b/spec/netbox_client_ruby/api/ipam/vlan_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NetboxClientRuby::IPAM::Vlan, faraday_stub: true do
   let(:response) { File.read("spec/fixtures/ipam/vlan_#{entity_id}.json") }
 
   let(:entity_id) { 1 }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { class_under_test.new entity_id }
 

--- a/spec/netbox_client_ruby/api/ipam/vrf_spec.rb
+++ b/spec/netbox_client_ruby/api/ipam/vrf_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NetboxClientRuby::IPAM::Vrf, faraday_stub: true do
   let(:response) { File.read("spec/fixtures/ipam/vrf_#{entity_id}.json") }
 
   let(:entity_id) { 1 }
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { class_under_test.new entity_id }
 

--- a/spec/netbox_client_ruby/api/secrets/secret_role_spec.rb
+++ b/spec/netbox_client_ruby/api/secrets/secret_role_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::Secrets::SecretRole, faraday_stub: true do
   let(:secret_id) { 1 }
   let(:base_url) { '/api/secrets/secret-roles/' }
-  let(:request_url) { "#{base_url}#{secret_id}.json" }
+  let(:request_url) { "#{base_url}#{secret_id}/" }
   let(:response) { File.read("spec/fixtures/secrets/secret-role_#{secret_id}.json") }
 
   subject { NetboxClientRuby::Secrets::SecretRole.new secret_id }

--- a/spec/netbox_client_ruby/api/secrets/secret_spec.rb
+++ b/spec/netbox_client_ruby/api/secrets/secret_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::Secrets::Secret, faraday_stub: true do
   let(:secret_id) { 1 }
   let(:base_url) { '/api/secrets/secrets/' }
-  let(:request_url) { "#{base_url}#{secret_id}.json" }
+  let(:request_url) { "#{base_url}#{secret_id}/" }
   let(:response) { File.read("spec/fixtures/secrets/secret_#{secret_id}.json") }
 
   subject { NetboxClientRuby::Secrets::Secret.new secret_id }

--- a/spec/netbox_client_ruby/api/tenancy/tenant_group_spec.rb
+++ b/spec/netbox_client_ruby/api/tenancy/tenant_group_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::Tenancy::TenantGroup, faraday_stub: true do
   let(:region_id) { 1 }
   let(:base_url) { '/api/tenancy/tenant-groups/' }
-  let(:request_url) { "#{base_url}#{region_id}.json" }
+  let(:request_url) { "#{base_url}#{region_id}/" }
   let(:response) { File.read("spec/fixtures/tenancy/tenant-group_#{region_id}.json") }
 
   subject { NetboxClientRuby::Tenancy::TenantGroup.new region_id }

--- a/spec/netbox_client_ruby/api/tenancy/tenant_spec.rb
+++ b/spec/netbox_client_ruby/api/tenancy/tenant_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe NetboxClientRuby::Tenancy::Tenant, faraday_stub: true do
   let(:region_id) { 1 }
   let(:base_url) { '/api/tenancy/tenants/' }
-  let(:request_url) { "#{base_url}#{region_id}.json" }
+  let(:request_url) { "#{base_url}#{region_id}/" }
   let(:response) { File.read("spec/fixtures/tenancy/tenant_#{region_id}.json") }
 
   subject { NetboxClientRuby::Tenancy::Tenant.new region_id }

--- a/spec/netbox_client_ruby/api/virtualization/cluster_group_spec.rb
+++ b/spec/netbox_client_ruby/api/virtualization/cluster_group_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::Virtualization::ClusterGroup, faraday_stub: tru
   let(:base_url) { '/api/virtualization/cluster-groups/' }
   let(:response) { File.read("spec/fixtures/virtualization/cluster-group_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/virtualization/cluster_spec.rb
+++ b/spec/netbox_client_ruby/api/virtualization/cluster_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::Virtualization::Cluster, faraday_stub: true do
   let(:base_url) { '/api/virtualization/clusters/' }
   let(:response) { File.read("spec/fixtures/virtualization/cluster_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/virtualization/cluster_type_spec.rb
+++ b/spec/netbox_client_ruby/api/virtualization/cluster_type_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::Virtualization::ClusterType, faraday_stub: true
   let(:base_url) { '/api/virtualization/cluster-types/' }
   let(:response) { File.read("spec/fixtures/virtualization/cluster-type_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/virtualization/interface_spec.rb
+++ b/spec/netbox_client_ruby/api/virtualization/interface_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::Virtualization::Interface, faraday_stub: true d
   let(:base_url) { '/api/virtualization/interfaces/' }
   let(:response) { File.read("spec/fixtures/virtualization/interface_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 

--- a/spec/netbox_client_ruby/api/virtualization/virtual_machine_spec.rb
+++ b/spec/netbox_client_ruby/api/virtualization/virtual_machine_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NetboxClientRuby::Virtualization::VirtualMachine, faraday_stub: t
   let(:base_url) { '/api/virtualization/virtual-machines/' }
   let(:response) { File.read("spec/fixtures/virtualization/virtual-machine_#{entity_id}.json") }
 
-  let(:request_url) { "#{base_url}#{entity_id}.json" }
+  let(:request_url) { "#{base_url}#{entity_id}/" }
 
   subject { described_class.new entity_id }
 


### PR DESCRIPTION
Netbox 4.1 throws an error if '.json' is appended to API requests. Previous versions silently ignored this deviation from the published API spec. This change corrects the requests for entities.

eg.
GET /api/ipam/ip-addresses/1/

instead of
GET /api/ipam/ip-addresses/1.json

Fixes #89 