### PR TITLE
Add ssl options for faraday

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ NetboxClientRuby.configure do |config|
   config.netbox.auth.rsa_private_key.password = ''
   config.netbox.pagination.default_limit = 50
   config.faraday.adapter = Faraday.default_adapter
+  # https://lostisland.github.io/faraday/#/customization/request-options
   config.faraday.request_options = { open_timeout: 1, timeout: 5 }
+  # see: https://lostisland.github.io/faraday/#/customization/ssl-options
+  config.faraday.ssl_options = { verify: true }
   config.faraday.logger = :logger # built-in options: :logger, :detailed_logger; default: nil
 end
 ```

--- a/lib/netbox_client_ruby.rb
+++ b/lib/netbox_client_ruby.rb
@@ -65,6 +65,7 @@ module NetboxClientRuby
     setting :adapter, default: :net_http
     setting :logger
     setting :request_options, default: { open_timeout: 1, timeout: 5 }
+    setting :ssl_options, default: { verify: true }
   end
 
   def self.circuits

--- a/lib/netbox_client_ruby/connection.rb
+++ b/lib/netbox_client_ruby/connection.rb
@@ -28,7 +28,7 @@ module NetboxClientRuby
 
     private_class_method def self.build_faraday(request_encoding: :json)
       config = NetboxClientRuby.config
-      Faraday.new(url: config.netbox.api_base_url, headers: headers) do |faraday|
+      Faraday.new(url: config.netbox.api_base_url, headers: headers, ssl: config.faraday.ssl_options) do |faraday|
         faraday.request request_encoding
         faraday.response config.faraday.logger if config.faraday.logger
         faraday.response :json, content_type: /\bjson$/

--- a/spec/netbox_client_ruby/netbox_spec.rb
+++ b/spec/netbox_client_ruby/netbox_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe NetboxClientRuby do
       config.faraday.adapter = :net_http_persistent
       config.faraday.logger = :detailed_logger
       config.faraday.request_options = { open_timeout: 3, timeout: 15 }
+      config.faraday.ssl_options = { verify: true }
     end
 
     expect(NetboxClientRuby.config.netbox.auth.token)
@@ -34,6 +35,8 @@ RSpec.describe NetboxClientRuby do
       .to be :detailed_logger
     expect(NetboxClientRuby.config.faraday.request_options)
       .to eq(open_timeout: 3, timeout: 15)
+    expect(NetboxClientRuby.config.faraday.ssl_options)
+      .to eq(verify: true)
   end
 
   {


### PR DESCRIPTION
I need to be able to integrate with an internal Netbox server that has an internally signed SSL cert, so I need to be able to pass the ssl information to Faraday as described here:

https://lostisland.github.io/faraday/#/customization/ssl-options
