### PR TITLE
refactor: move hash_to_object method where it should belong

### DIFF
--- a/lib/netbox_client_ruby/communication.rb
+++ b/lib/netbox_client_ruby/communication.rb
@@ -15,24 +15,7 @@ module NetboxClientRuby
       NetboxClientRuby::Connection.new
     end
 
-    def hash_to_object(hash)
-      objectified_class = Class.new
-      objectified_instance = objectified_class.new
-      hash.each do |k, v|
-        variable_name = sanitize_variable_name(k)
-        variable_name = "_#{variable_name}" if objectified_instance.methods.map(&:to_s).include?(variable_name)
-
-        objectified_instance.instance_variable_set(:"@#{variable_name}", v)
-        objectified_class.send(:define_method, variable_name, proc { instance_variable_get(:"@#{variable_name}") })
-      end
-      objectified_instance
-    end
-
     private
-
-    def sanitize_variable_name(raw_name)
-      raw_name.gsub(/[^a-zA-Z0-9_]/, '_')
-    end
 
     def read(response)
       response.body

--- a/lib/netbox_client_ruby/entity.rb
+++ b/lib/netbox_client_ruby/entity.rb
@@ -275,6 +275,23 @@ module NetboxClientRuby
       self.class.object_fields
     end
 
+    def hash_to_object(hash)
+      objectified_class = Class.new
+      objectified_instance = objectified_class.new
+      hash.each do |k, v|
+        variable_name = sanitize_variable_name(k)
+        variable_name = "_#{variable_name}" if objectified_instance.methods.map(&:to_s).include?(variable_name)
+
+        objectified_instance.instance_variable_set(:"@#{variable_name}", v)
+        objectified_class.send(:define_method, variable_name, proc { instance_variable_get(:"@#{variable_name}") })
+      end
+      objectified_instance
+    end
+
+    def sanitize_variable_name(raw_name)
+      raw_name.gsub(/[^a-zA-Z0-9_]/, '_')
+    end
+
     def data_to_obj(raw_data, klass_or_proc = nil)
       if klass_or_proc.nil?
         hash_to_object raw_data


### PR DESCRIPTION
Hi there!

`hash_to_object` and `sanitize_variable_name` methods should be in `Entity` module : it's only called by `data_to_obj` (which is in `Entity` module)

Thank you!